### PR TITLE
[baz-feat] 게임 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18601,7 +18601,6 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -18619,7 +18618,6 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -18650,7 +18648,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -18662,7 +18659,6 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -18713,7 +18709,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -18722,7 +18717,6 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -18733,7 +18727,6 @@
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -18765,7 +18758,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "optional": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"

--- a/src/components/OceanSelection.tsx
+++ b/src/components/OceanSelection.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import OceanInfo from 'types/OceanInfo';
+
+interface OceanSelectionProps extends React.HTMLProps<HTMLDivElement> {
+  ocean: OceanInfo;
+}
+
+// TODO: 선택시 인터렉션 필요
+const OceanSelection = ({ ocean, onClick }: OceanSelectionProps) => (
+  <Selection onClick={onClick}>
+    <img src={ocean.imageSrc} alt="ocean" />
+    <Title>{ocean.name}</Title>
+    <Description>{ocean.description}</Description>
+  </Selection>
+);
+
+export default OceanSelection;
+
+const Selection = styled.div`
+  position: relative;
+  width: 50%;
+  height: 100%;
+  background-color: blue;
+  border: 1px solid black;
+  cursor: pointer;
+
+  > img {
+    width: 100%;
+    height: 100%;
+  }
+`;
+
+const Title = styled.div`
+  position: absolute;
+  width: 100%;
+  top: 30px;
+  color: white;
+  text-align: center;
+  font-size: 30px;
+  font-weight: bold;
+`;
+
+const Description = styled.div`
+  position: absolute;
+  width: 100%;
+  bottom: 30px;
+  color: white;
+  text-align: center;
+  font-size: 20px;
+  font-weight: bold;
+`;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ import { HelmetProvider } from 'react-helmet-async';
 import App from 'App';
 import * as serviceWorker from 'serviceWorker';
 import 'sanitize.css/sanitize.css';
-import 'antd/dist/antd.less';
+import 'antd/dist/antd.css';
 
 ReactDOM.render(
   <HelmetProvider>

--- a/src/pages/game.tsx
+++ b/src/pages/game.tsx
@@ -77,7 +77,8 @@ const GamePage = () => {
     <Layout style={{ height: '100vh' }}>
       <Header>
         <Logo>
-          바다 이상형 월드컵 {round}라운드 {count}차
+          나랑 바다 갈래? {round}라운드(
+          {originInfos.length / Math.pow(2, round - 1)}강) {count}차
         </Logo>
       </Header>
       <Content style={{ display: 'flex' }}>

--- a/src/pages/game.tsx
+++ b/src/pages/game.tsx
@@ -1,7 +1,101 @@
-import React from 'react';
+import { Layout } from 'antd';
+import { Content, Footer, Header } from 'antd/lib/layout/layout';
+import OceanSelection from 'components/OceanSelection';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import TravelService from 'services/TravelService';
+import styled from 'styled-components';
+
+import OceanInfo from 'types/OceanInfo';
+
+// 16이면 16강, 32면 32강 가능
+const MAX_ITEM_COUNT = 16;
 
 const GamePage = () => {
-  return <>Game</>;
+  const [round, setRound] = useState(1);
+  const [currIndex, setCurrIndex] = useState(MAX_ITEM_COUNT - 2);
+  const [oceanInfos, setOceanInfos] = useState<OceanInfo[]>([]);
+  const history = useHistory();
+
+  useEffect(() => {
+    (async () => {
+      // 초기 해수욕장 정보들을 불러와 MAX_ITEM_COUNT만큼 저장하는 부분
+      const allInfos = await TravelService.getSomethingTravel();
+
+      const infos = allInfos
+        .sort(() => Math.random() - Math.random())
+        .slice(0, MAX_ITEM_COUNT);
+
+      setOceanInfos(infos);
+    })();
+  }, []);
+
+  const leftOcean = useMemo(() => oceanInfos[currIndex], [
+    currIndex,
+    oceanInfos,
+  ]);
+  const rightOcean = useMemo(() => oceanInfos[currIndex + 1], [
+    currIndex,
+    oceanInfos,
+  ]);
+
+  // 1라운드 n차 구현인데 증가하는게 이상해서 로직을 다시 생각해야함
+  // 원하는 방향(1차 -> 2차 -> 3차...)
+  // 실제 방향(1차 -> 1.5차 -> 2차...)
+  const position = useMemo(() => (oceanInfos.length - currIndex) / 2, [
+    oceanInfos,
+    currIndex,
+  ]);
+
+  const handleSelect = useCallback(
+    (isLeft: boolean) => {
+      const startIndex = isLeft ? currIndex + 1 : currIndex;
+      const newOceanInfos = [...oceanInfos];
+      newOceanInfos.splice(startIndex, 1);
+
+      if (newOceanInfos.length === 1) {
+        // 최종 결과가 1개만 남은 경우
+        history.push('/result', {
+          ocean: newOceanInfos[0],
+        });
+      } else if (currIndex > 0) {
+        // 현재 차수가 남아있는 경우
+        setCurrIndex(currIndex - 2);
+        setOceanInfos(newOceanInfos);
+      } else {
+        // 차수에 더 이상 진행할 선택이 없는 경우 라운드를 추가하고 다시 돈다(16강 -> 8강)
+        setRound(round + 1);
+        setCurrIndex(newOceanInfos.length - 2);
+        setOceanInfos(newOceanInfos.sort(() => Math.random() - Math.random()));
+      }
+    },
+    [oceanInfos, currIndex, round],
+  );
+
+  if (!oceanInfos.length) {
+    return <></>;
+  }
+
+  return (
+    <Layout style={{ height: '100vh' }}>
+      <Header>
+        <Logo>
+          바다 이상형 월드컵 {round}라운드 {position}차
+        </Logo>
+      </Header>
+      <Content style={{ display: 'flex' }}>
+        <OceanSelection ocean={leftOcean} onClick={() => handleSelect(true)} />
+        <OceanSelection
+          ocean={rightOcean}
+          onClick={() => handleSelect(false)}
+        />
+      </Content>
+    </Layout>
+  );
 };
 
 export default GamePage;
+
+const Logo = styled.div`
+  color: white;
+`;

--- a/src/pages/game.tsx
+++ b/src/pages/game.tsx
@@ -1,11 +1,11 @@
 import { Layout } from 'antd';
-import { Content, Footer, Header } from 'antd/lib/layout/layout';
-import OceanSelection from 'components/OceanSelection';
+import { Content, Header } from 'antd/lib/layout/layout';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import TravelService from 'services/TravelService';
 import styled from 'styled-components';
 
+import OceanSelection from 'components/OceanSelection';
+import TravelService from 'services/TravelService';
 import OceanInfo from 'types/OceanInfo';
 
 // 16이면 16강, 32면 32강 가능

--- a/src/pages/game.tsx
+++ b/src/pages/game.tsx
@@ -13,8 +13,10 @@ const MAX_ITEM_COUNT = 16;
 
 const GamePage = () => {
   const [round, setRound] = useState(1);
+  const [count, setCount] = useState(1);
   const [currIndex, setCurrIndex] = useState(MAX_ITEM_COUNT - 2);
   const [oceanInfos, setOceanInfos] = useState<OceanInfo[]>([]);
+  const [originInfos, setOriginInfos] = useState<OceanInfo[]>([]);
   const history = useHistory();
 
   useEffect(() => {
@@ -27,6 +29,7 @@ const GamePage = () => {
         .slice(0, MAX_ITEM_COUNT);
 
       setOceanInfos(infos);
+      setOriginInfos(infos);
     })();
   }, []);
 
@@ -37,14 +40,6 @@ const GamePage = () => {
   const rightOcean = useMemo(() => oceanInfos[currIndex + 1], [
     currIndex,
     oceanInfos,
-  ]);
-
-  // 1라운드 n차 구현인데 증가하는게 이상해서 로직을 다시 생각해야함
-  // 원하는 방향(1차 -> 2차 -> 3차...)
-  // 실제 방향(1차 -> 1.5차 -> 2차...)
-  const position = useMemo(() => (oceanInfos.length - currIndex) / 2, [
-    oceanInfos,
-    currIndex,
   ]);
 
   const handleSelect = useCallback(
@@ -62,14 +57,16 @@ const GamePage = () => {
         // 현재 차수가 남아있는 경우
         setCurrIndex(currIndex - 2);
         setOceanInfos(newOceanInfos);
+        setCount(count + 1);
       } else {
         // 차수에 더 이상 진행할 선택이 없는 경우 라운드를 추가하고 다시 돈다(16강 -> 8강)
         setRound(round + 1);
         setCurrIndex(newOceanInfos.length - 2);
         setOceanInfos(newOceanInfos.sort(() => Math.random() - Math.random()));
+        setCount(1);
       }
     },
-    [oceanInfos, currIndex, round],
+    [oceanInfos, currIndex, round, count, history],
   );
 
   if (!oceanInfos.length) {
@@ -80,7 +77,7 @@ const GamePage = () => {
     <Layout style={{ height: '100vh' }}>
       <Header>
         <Logo>
-          바다 이상형 월드컵 {round}라운드 {position}차
+          바다 이상형 월드컵 {round}라운드 {count}차
         </Logo>
       </Header>
       <Content style={{ display: 'flex' }}>

--- a/src/services/TravelService.ts
+++ b/src/services/TravelService.ts
@@ -1,17 +1,35 @@
-import convert from 'xml-js';
 import axios from 'axios';
 
+import OceanInfo from 'types/OceanInfo';
 class TravelService {
   async getSomethingTravel() {
     const res = await axios.get(
-      'http://api.visitkorea.or.kr/openapi/service/rest/KorService/searchKeyword',
+      'http://api.visitkorea.or.kr/openapi/service/rest/KorService/areaBasedList',
       {
-        params: { serviceKey: process.env.REACT_APP_TRAVEL_KEY },
+        params: {
+          serviceKey: decodeURIComponent(process.env.REACT_APP_TRAVEL_KEY!),
+          MobileApp: 'AppTest',
+          MobileOS: 'ETC',
+          pageNo: 1,
+          numOfRows: 300,
+          contentTypeId: 12,
+          cat1: 'A01',
+          cat2: 'A0101',
+          cat3: 'A01011200',
+          listYN: 'Y',
+        },
       },
     );
-    const json = convert.xml2json(res.data);
 
-    return json;
+    if (!res?.data?.response?.body?.items?.item) {
+      throw res;
+    }
+
+    return res.data.response.body.items.item.map(item => ({
+      name: item.title,
+      imageSrc: item.firstimage,
+      description: item.addr1,
+    })) as OceanInfo[];
   }
 }
 

--- a/src/types/OceanInfo.ts
+++ b/src/types/OceanInfo.ts
@@ -1,0 +1,7 @@
+interface OceanInfo {
+  imageSrc: string;
+  name: string;
+  description: string;
+}
+
+export default OceanInfo;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/312621/108108773-684a2780-70d4-11eb-9888-344101d8497b.png)

바다 이상형 월드컵을 구현한 PR입니다.

구현 완료한 내용
- 바다 이미지들을 가져와서 필요한 수만큼 랜덤으로 추출
- 임의적으로 라운드를 조절할 수 있도록 `MAX_ITEM_COUNT`를 부여(초기값 16이고 8이나 32처럼 다른 숫자도 가능) 
- 선택시 다음 차수로 진출할 수 있도록 구현
- 최종 1개만 남았을 때 `/result`로 이동

구현이 더 필요한 부분
- 선택했을 때 중앙으로 오는 인터랙션
- 결과값을 전달할때 초기 16개의 해수욕장과 최종 선택된 1개의 해수욕장을 전달해줘야함

보기 어려운 부분도 있을 수 있으니 참고 부탁드림당
다른 팀분들께) 아직 완성은 아닙니다!