### PR TITLE
[baz-feat] 결과 페이지 구현

### DIFF
--- a/src/components/OceanSelection.tsx
+++ b/src/components/OceanSelection.tsx
@@ -5,11 +5,12 @@ import OceanInfo from 'types/OceanInfo';
 
 interface OceanSelectionProps extends React.HTMLProps<HTMLDivElement> {
   ocean: OceanInfo;
+  isResult?: boolean;
 }
 
 // TODO: 선택시 인터렉션 필요
-const OceanSelection = ({ ocean, onClick }: OceanSelectionProps) => (
-  <Selection onClick={onClick}>
+const OceanSelection = ({ ocean, isResult, onClick }: OceanSelectionProps) => (
+  <Selection isResult={isResult} onClick={onClick}>
     <img src={ocean.imageSrc} alt="ocean" />
     <Title>{ocean.name}</Title>
     <Description>{ocean.description}</Description>
@@ -18,13 +19,13 @@ const OceanSelection = ({ ocean, onClick }: OceanSelectionProps) => (
 
 export default OceanSelection;
 
-const Selection = styled.div`
+const Selection = styled.div<{ isResult?: boolean }>`
   position: relative;
   width: 50%;
   height: 100%;
   background-color: blue;
   border: 1px solid black;
-  cursor: pointer;
+  cursor: ${props => (props.isResult ? '' : 'pointer')};
 
   > img {
     width: 100%;

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -6,15 +6,18 @@ import OceanSelection from 'components/OceanSelection';
 import OceanInfo from 'types/OceanInfo';
 import { serialize } from 'util/crypto';
 
+type FlagType = 'initial' | 'correct' | 'incorrect';
+
 const ResultPage = ({ location: { state } }) => {
   const [ocean] = useState<OceanInfo>(state.ocean);
   const encoded = serialize(state);
   const url = new URL(encoded, 'http://localhost:3000/');
   const shortenUrl = url.href.substring(0, 37) + ' ...';
+  const flag: FlagType = state.flag || 'initial';
   const messages = {
-    initial: '',
-    correct: '',
-    incorrect: '',
+    initial: `"${ocean.name}"에 같이 가고 싶은 사람에게 링크를 공유하세요!`,
+    correct: `바다 좀 볼 줄 아는군? 같이 "${ocean.name}" 보러 가자구~`,
+    incorrect: `"${ocean.name}" 보러 가고 싶었다능..`,
   };
 
   const onClick = useCallback(() => {
@@ -29,11 +32,13 @@ const ResultPage = ({ location: { state } }) => {
       <Content style={{ display: 'flex' }}>
         <OceanSelection ocean={ocean} />
         <Description>
-          <MessageBox>{messages.initial}</MessageBox>
-          <UrlBox>
-            <UrlInput disabled value={shortenUrl} />
-            <CopyButton onClick={onClick}>Copy</CopyButton>
-          </UrlBox>
+          <MessageBox>{messages[flag]}</MessageBox>
+          {flag === 'initial' && (
+            <UrlBox>
+              <UrlInput disabled value={shortenUrl} />
+              <CopyButton onClick={onClick}>Copy</CopyButton>
+            </UrlBox>
+          )}
         </Description>
       </Content>
     </Layout>

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -4,9 +4,13 @@ import { Content, Header } from 'antd/lib/layout/layout';
 import styled from 'styled-components';
 import OceanSelection from 'components/OceanSelection';
 import OceanInfo from 'types/OceanInfo';
+import { serialize } from 'util/crypto';
 
 const ResultPage = ({ location: { state } }) => {
   const [ocean] = useState<OceanInfo>(state.ocean);
+  const encoded = serialize(state);
+  const url = new URL(encoded, 'http://localhost:3000/');
+  const shortenUrl = url.href.substring(0, 37) + ' ...';
   const messages = {
     initial: '',
     correct: '',
@@ -22,6 +26,10 @@ const ResultPage = ({ location: { state } }) => {
         <OceanSelection ocean={ocean} />
         <Description>
           <MessageBox>{messages.initial}</MessageBox>
+          <UrlBox>
+            <UrlInput disabled value={shortenUrl} />
+            <CopyButton>Copy</CopyButton>
+          </UrlBox>
         </Description>
       </Content>
     </Layout>
@@ -48,4 +56,29 @@ const MessageBox = styled.div`
   align-items: center;
   height: 50%;
   font-size: 24px;
+`;
+
+const UrlBox = styled.div`
+  display: flex;
+  height: 50%;
+`;
+const UrlInput = styled.input`
+  width: 450px;
+  font-size: 20px;
+  height: 50px;
+  text-align: center;
+  border: 0;
+  border-radius: 7px;
+  background-color: #f4f7ff;
+`;
+const CopyButton = styled.button`
+  width: 77px;
+  height: 48px;
+  font-size: 16px;
+  margin-left: 12px;
+  border: 0;
+  border-radius: 7px;
+  background-color: #001529;
+  color: #e5eafe;
+  cursor: pointer;
 `;

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -1,7 +1,51 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Layout } from 'antd';
+import { Content, Header } from 'antd/lib/layout/layout';
+import styled from 'styled-components';
+import OceanSelection from 'components/OceanSelection';
+import OceanInfo from 'types/OceanInfo';
 
-const ResultPage = () => {
-  return <>Result</>;
+const ResultPage = ({ location: { state } }) => {
+  const [ocean] = useState<OceanInfo>(state.ocean);
+  const messages = {
+    initial: '',
+    correct: '',
+    incorrect: '',
+  };
+
+  return (
+    <Layout style={{ height: '100vh' }}>
+      <Header>
+        <Logo>나랑 바다 갈래?</Logo>
+      </Header>
+      <Content style={{ display: 'flex' }}>
+        <OceanSelection ocean={ocean} />
+        <Description>
+          <MessageBox>{messages.initial}</MessageBox>
+        </Description>
+      </Content>
+    </Layout>
+  );
 };
 
 export default ResultPage;
+
+const Logo = styled.div`
+  color: white;
+`;
+
+const Description = styled.div`
+  width: 50%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const MessageBox = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 50%;
+  font-size: 24px;
+`;

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Layout } from 'antd';
 import { Content, Header } from 'antd/lib/layout/layout';
 import styled from 'styled-components';
@@ -17,6 +17,10 @@ const ResultPage = ({ location: { state } }) => {
     incorrect: '',
   };
 
+  const onClick = useCallback(() => {
+    navigator.clipboard.writeText(url.href);
+  }, [url.href]);
+
   return (
     <Layout style={{ height: '100vh' }}>
       <Header>
@@ -28,7 +32,7 @@ const ResultPage = ({ location: { state } }) => {
           <MessageBox>{messages.initial}</MessageBox>
           <UrlBox>
             <UrlInput disabled value={shortenUrl} />
-            <CopyButton>Copy</CopyButton>
+            <CopyButton onClick={onClick}>Copy</CopyButton>
           </UrlBox>
         </Description>
       </Content>

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -30,7 +30,7 @@ const ResultPage = ({ location: { state } }) => {
         <Logo>나랑 바다 갈래?</Logo>
       </Header>
       <Content style={{ display: 'flex' }}>
-        <OceanSelection ocean={ocean} />
+        <OceanSelection isResult ocean={ocean} />
         <Description>
           <MessageBox>{messages[flag]}</MessageBox>
           {flag === 'initial' && (

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -13,11 +13,12 @@ const ResultPage = ({ location: { state } }) => {
   const encoded = serialize(state);
   const url = new URL(encoded, 'http://localhost:3000/');
   const shortenUrl = url.href.substring(0, 37) + ' ...';
-  const flag: FlagType = state.flag || 'initial';
+  const flag: FlagType = state.flag || 'correct';
+  const name = '민수르';
   const messages = {
     initial: `"${ocean.name}"에 같이 가고 싶은 사람에게 링크를 공유하세요!`,
-    correct: `바다 좀 볼 줄 아는군? 같이 "${ocean.name}" 보러 가자구~`,
-    incorrect: `"${ocean.name}" 보러 가고 싶었다능..`,
+    correct: `바다 좀 볼 줄 아는군? ${name}와 함께 "${ocean.name}" 보러 가자구~`,
+    incorrect: `${name}는 "${ocean.name}" 보러 가고 싶었다능..`,
   };
 
   const onClick = useCallback(() => {


### PR DESCRIPTION
구현 완료한 내용
- result 페이지에 상황에 따른 메세지와 url 생성 및 복사 컴포넌트 노출
- url 생성은 crypto-js를 이용하여 state를 암호화하여 생성
- url 복사는 navigator.clipboard 사용하여 구현

구현이 더 필요한 부분
- 각 페이지별 state 연동

스크린샷
1. url 생성화면
![image](https://user-images.githubusercontent.com/40910757/108243280-3fd43300-7191-11eb-804c-6d9629ce4430.png)
2. 공유받은 사람이 맞췄을 때
![image](https://user-images.githubusercontent.com/40910757/108243330-4c588b80-7191-11eb-9c93-9a0385d7963a.png)
3. 공유받은 사람이 틀렸을 때
![image](https://user-images.githubusercontent.com/40910757/108243372-58dce400-7191-11eb-8d76-33bde90ce23d.png)
